### PR TITLE
Using dependency information for creating a hash value

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ Configure what should be hashed and saved where:
 ```
   :files-hash [{:properties-file "resources/versions.properties"
                 :property-key "graph-hash"
+                :deps  ["org.some.dependency/dependency"
+                        "org.some.other.dependency/other-dependency"]
                 :paths ["src/de/otto/package1"
                         "src/de/otto/package2"]}]
 ```
 
-This will then on invocation create a SHA-256 Merkle hash tree of all files and
-their names under the given paths and save the resulting hash under the given
-key in the given properties file.  As the format hints, you can have multiple
+This will then on invocation create a SHA-256 Merkle hash tree of all files 
+(using filenames under the given paths) and dependencies (using dependency names and 
+the corresponding version). The resulting hash is stored under the given
+key in the given properties file. As the format hints, you can have multiple
 such configurations.  You can also refer to single file names in the paths
 vector.
 

--- a/src/leiningen/files_hash.clj
+++ b/src/leiningen/files_hash.clj
@@ -72,7 +72,8 @@
 (spec/def ::property-key string?)
 (spec/def ::paths (spec/coll-of string?))
 (spec/def ::deps (spec/coll-of string?))
-(spec/def ::config (spec/keys :req-un [::properties-file ::property-key ::paths ::deps]))
+(spec/def ::config (spec/keys :req-un [::properties-file ::property-key]
+                              :opt-un [::paths ::deps]))
 (spec/def ::configs (spec/coll-of ::config))
 
 (defn files-hash

--- a/src/leiningen/files_hash.clj
+++ b/src/leiningen/files_hash.clj
@@ -50,15 +50,17 @@
        (into-array Byte/TYPE)))
 
 (defn path->hashable [paths]
-  (->> paths
-       (mapv io/file)))
+  (->> (mapv io/file paths)
+       (sort)))
 
 (defn deps->hashable [deps]
   (let [deps-set (set deps)]
     (->> (mapv (fn [[name version]]
-                 [(str name) (str version)]) (:dependencies (project/read)))
+                 [(str name) (str version)])
+               (:dependencies (project/read)))
          (filterv (fn [[name]] (contains? deps-set name)))
-         (mapv (partial str/join ":")))))
+         (mapv (partial str/join ":"))
+         (sort))))
 
 (defn hash [& args]
   (->> (apply concat args)

--- a/test/leiningen/files_hash_test.clj
+++ b/test/leiningen/files_hash_test.clj
@@ -1,10 +1,10 @@
 (ns leiningen.files-hash-test
   (:require [clojure.java.io :as io]
-            [clojure.string :as string]
             [clojure.test :refer [deftest is testing]]
             [clojure.test.check.generators :as gen]
             [leiningen.files-hash :as files-hash]
-            [leiningen.files-hash.props :as props])
+            [leiningen.files-hash.props :as props]
+            [leiningen.core.project :as project])
   (:import [java.nio.file CopyOption Files Paths StandardCopyOption]
            [java.util Properties]))
 
@@ -69,49 +69,61 @@
                           :dir
                           (slurp (.getPath f)))])))
 
-(deftest test-files-hash
+(deftest deps->hashable-test
+  (is (= ["org.clojure/clojure:1.10.1"]
+         (files-hash/deps->hashable ["org.clojure/clojure"])))
+  (is (= ["org.clojure/clojure:1.10.1" "nrepl/nrepl:0.6.0"]
+         (files-hash/deps->hashable ["org.clojure/clojure" "nrepl/nrepl"]))))
+
+(deftest files-hash-test
   (let [test-dir "tmp/testdir"
         propfile "tmp/test.properties"
         property-key "testdir-hash"
+        deps ["org.clojure/clojure"]
         make-hash (fn []
                     (files-hash/files-hash {:files-hash [{:properties-file propfile
-                                                          :property-key property-key
-                                                          :paths [test-dir]}]})
+                                                          :property-key    property-key
+                                                          :deps            deps
+                                                          :paths           [test-dir]}]})
                     (-> (props/load-props propfile)
                         (get property-key)))]
     (dotimes [n 50]
       (with-random-tree test-dir
-        (testing "creates a valid hash file"
-          (let [hash (make-hash)]
-            (is (= 64 (count hash))
-                {:dir-state (str (report-dir-state test-dir))
-                 :hash hash})
-            (is (every? int?
-                        (mapv #(Integer/parseInt (subs hash % (+ % 2)) 16)
-                              (mapv (partial * 2) (range 32))))
-                (str (report-dir-state test-dir)))))
-        (testing "hashing again gives the same result"
-          (is (= (make-hash) (make-hash))
-              (str (report-dir-state test-dir))))
-        (testing "modifying a file name changes the hash"
-          (let [hash-before (make-hash)
-                files (rest (file-seq (io/file test-dir)))]
-            (when (not-empty files)
-              (let [f (rand-nth files)]
-                (rename-file f (change-random-char (.getName f)))
-                (is (not= hash-before (make-hash))
-                    (str (report-dir-state test-dir)))))))
-        (testing "modifying file content changes the hash"
-          (let [hash-before (make-hash)
-                files (->> (file-seq (io/file test-dir))
-                           (remove #(.isDirectory %)))]
-            (when (not-empty files)
-              (let [f (rand-nth files)]
-                (spit f (change-random-char (slurp f)))
-                (is (not= hash-before (make-hash))
-                    (str (report-dir-state test-dir)))))))
-        (testing "an existing properties file doesn't lose other keys"
-          (props/store-props {"foo" "bar"} propfile :comment "test")
-          (is (= 64 (count (make-hash))))
-          (is (= "bar" (get (props/load-props propfile) "foo")))))
+                        (testing "creates a valid hash file"
+                          (let [hash (make-hash)]
+                            (is (= 64 (count hash))
+                                {:dir-state (str (report-dir-state test-dir))
+                                 :hash      hash})
+                            (is (every? int?
+                                        (mapv #(Integer/parseInt (subs hash % (+ % 2)) 16)
+                                              (mapv (partial * 2) (range 32))))
+                                (str (report-dir-state test-dir)))))
+                        (testing "hashing again gives the same result"
+                          (is (= (make-hash) (make-hash))
+                              (str (report-dir-state test-dir))))
+                        (testing "modifying a file name changes the hash"
+                          (let [hash-before (make-hash)
+                                files (rest (file-seq (io/file test-dir)))]
+                            (when (not-empty files)
+                              (let [f (rand-nth files)]
+                                (rename-file f (change-random-char (.getName f)))
+                                (is (not= hash-before (make-hash))
+                                    (str (report-dir-state test-dir)))))))
+                        (testing "modifying file content changes the hash"
+                          (let [hash-before (make-hash)
+                                files (->> (file-seq (io/file test-dir))
+                                           (remove #(.isDirectory %)))]
+                            (when (not-empty files)
+                              (let [f (rand-nth files)]
+                                (spit f (change-random-char (slurp f)))
+                                (is (not= hash-before (make-hash))
+                                    (str (report-dir-state test-dir)))))))
+                        (testing "modifying dependency version changes the hash"
+                          (with-redefs [project/read (fn [] {:dependencies [["org.clojure/clojure" (str (rand))]]})]
+                            (let [hash-before (make-hash)]
+                              (is (not= hash-before (make-hash))))))
+                        (testing "an existing properties file doesn't lose other keys"
+                          (props/store-props {"foo" "bar"} propfile :comment "test")
+                          (is (= 64 (count (make-hash))))
+                          (is (= "bar" (get (props/load-props propfile) "foo")))))
       (delete-dir "tmp"))))

--- a/test/leiningen/files_hash_test.clj
+++ b/test/leiningen/files_hash_test.clj
@@ -5,8 +5,7 @@
             [leiningen.files-hash :as files-hash]
             [leiningen.files-hash.props :as props]
             [leiningen.core.project :as project])
-  (:import [java.nio.file CopyOption Files Paths StandardCopyOption]
-           [java.util Properties]))
+  (:import [java.nio.file CopyOption Files Paths StandardCopyOption]))
 
 (defn gen-1 [g]
   (first (gen/sample g 1)))
@@ -72,7 +71,7 @@
 (deftest deps->hashable-test
   (is (= ["org.clojure/clojure:1.10.1"]
          (files-hash/deps->hashable ["org.clojure/clojure"])))
-  (is (= ["org.clojure/clojure:1.10.1" "nrepl/nrepl:0.6.0"]
+  (is (= ["nrepl/nrepl:0.6.0" "org.clojure/clojure:1.10.1"]
          (files-hash/deps->hashable ["org.clojure/clojure" "nrepl/nrepl"]))))
 
 (deftest files-hash-test


### PR DESCRIPTION
New functionality: given dependencies (and their versions from project.clj)
are used in addition to create a hash value for the
property key